### PR TITLE
Fix Windows MSVC CRT mismatch linker error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/NODEFAULTLIB:LIBCMT"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/NODEFAULTLIB:LIBCMT"]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1173,9 +1173,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "event-listener"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ directories = "5.0"
 symphonia = { version = "0.5", features = ["mp3", "wav", "flac"] }
 image = "0.24"
 ndarray = "0.16.1"
-tokenizers = { version = "0.22.1" }
+tokenizers = { version = "0.22.1", default-features = false, features = ["progressbar", "onig"] }
 thiserror = "1.0"
 base64 = "0.22"
 


### PR DESCRIPTION
Two changes to resolve LNK2005/LNK2038 multiply-defined symbol errors:

1. Add .cargo/config.toml with /NODEFAULTLIB:LIBCMT for Windows MSVC targets to prevent the static/dynamic CRT conflict introduced by having both staticlib and cdylib crate types.

2. Disable the esaxx_fast default feature on the tokenizers dependency. That feature pulls in esaxx-rs/cpp, which compiles C++ with .static_crt(true) (/MT), conflicting with the prebuilt ort_sys (ONNX Runtime) binaries that use /MD. The pure-Rust fallback is used instead with no functional impact.