### PR TITLE
Yet another WinML DLL Hell fix.  Writing notes by hand to save tokens

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "link-args=/NODEFAULTLIB:LIBCMT"]
+rustflags = []
 
 [target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "link-args=/NODEFAULTLIB:LIBCMT"]
+rustflags = []

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3075,6 +3075,7 @@ version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
 dependencies = [
+ "libloading 0.8.9",
  "ndarray",
  "ort-sys",
  "smallvec 2.0.0-alpha.10",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # to make the lib name unique and wouldn't conflict with the bin name.
 # This seems to be only an issue on Windows, see https://github.com/rust-lang/cargo/issues/8519
 name = "baseweightcanvas_lib"
-crate-type = ["staticlib", "cdylib", "rlib"]
+crate-type = ["staticlib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
@@ -39,7 +39,7 @@ base64 = "0.22"
 
 # ONNX Runtime with platform-specific execution providers
 [target.'cfg(target_os = "windows")'.dependencies]
-ort = { version = "=2.0.0-rc.10", features = ["directml", "download-binaries"] }
+ort = { version = "=2.0.0-rc.10", features = ["directml", "load-dynamic"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 ort = { version = "=2.0.0-rc.10", features = ["cuda", "download-binaries"] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,11 +46,6 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "resources": {
-      "libs/windows-x64/DirectML.dll": ".",
-      "libs/windows-x64/onnxruntime.dll": ".",
-      "libs/windows-x64/onnxruntime_providers_shared.dll": "."
-    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "libs/windows-x64/DirectML.dll": ".",
+      "libs/windows-x64/onnxruntime.dll": ".",
+      "libs/windows-x64/onnxruntime_providers_shared.dll": "."
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src-tauri/tauri.windows.json
+++ b/src-tauri/tauri.windows.json
@@ -1,0 +1,13 @@
+{
+  "bundle": {
+    "resources": {
+      "libs/windows-x64/DirectML.dll": ".",
+      "libs/windows-x64/onnxruntime.dll": ".",
+      "libs/windows-x64/onnxruntime_providers_shared.dll": "."
+    },
+    "windows": {
+      "wix": { "language": "en-US" },
+      "nsis": { "languages": ["English"] }
+    }
+  }
+}


### PR DESCRIPTION
So....for some reason pyke-ort's fetch ORT shat the bed and now we need to use dynamic libraries.  As someone who spent two or three years working with ONNX Runtime, this isn't that big of a deal, but it's annoying that this is a chore again.

At any rate, since the next release is going to have ONNX Runtime support since I have plans for a product, we should make sure this works well.